### PR TITLE
feat: add Front Matter support for Markdown documents

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,19 @@
 - [x] Ajouter un SpashScreen avec Nom de l'application, version, auteur, contact et copyright ( command dans "about")
 - [x] Ajouter le support de plantuml et de mermaid,
 - [x] Ajouter le support de MathML,
-- [ ] Ajouter un editeur de "Front Matter" pour les docs Markdown.
+- [x] Ajouter un editeur de "Front Matter" pour les docs Markdown (voir plus bas).
 - [ ] Ajouter des themes pour le syntax highligther avec gestion dans les options. 
 - [ ] Ajouter le support de template de pages
 - [ ] Ajouter un panel "Assistant" permettant la connexion à un LLM via un MCP agent (ajouter un onlget "MCP agent" dans le dialogue "Options" pour configurer url, parameètres et clé d'API).
  
+## Front Matter
+
+ maintenant je souhaite ajouter le support des attributes de "Front Matter" dans le fichier markdown, ainsi on peu ajouter des attributs:
+- `title` pour le titre de l'article (il devra être utilisé dans l'explorateur de projet si celui-ci existe)
+- `author` un auteur ou une liste d'auteurs
+- `created_at` la date de création de la note au `formaat YYYY-MM-DD (hh:mm)`   l'heure étant optionnelle,
+- `tags` une liste de tag `[tag2,tag2,tag3]`
+- `summary` un résumé de l'article/de la note (optionel)
+- `draft` status de la note (si elle est publiée ou non: publiée si draft=false)
+
+> **IMPORTANT** Tous ces élément pourront être utilisé plus tard dans un moteur de recherche de note.

--- a/src/main/java/MarkNote.java
+++ b/src/main/java/MarkNote.java
@@ -285,12 +285,12 @@ public class MarkNote extends Application {
         // Mettre à jour la preview quand on change d'onglet
         mainTabPane.getSelectionModel().selectedItemProperty().addListener((obs, oldTab, newTab) -> {
             if (newTab instanceof DocumentTab docTab) {
-                previewPanel.updatePreview(docTab.getTextContent());
+                previewPanel.updatePreview(docTab.getFullContent());
             }
         });
 
         // Initial preview
-        previewPanel.updatePreview(tab.getTextContent());
+        previewPanel.updatePreview(tab.getFullContent());
     }
 
     /**

--- a/src/main/java/ui/FrontMatterPanel.java
+++ b/src/main/java/ui/FrontMatterPanel.java
@@ -1,0 +1,189 @@
+package ui;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import utils.FrontMatter;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TitledPane;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+
+/**
+ * Panneau d'édition des attributs Front Matter d'un document Markdown.
+ * <p>
+ * Affiche un formulaire avec les champs : title, author, created_at, tags,
+ * summary et draft. Le panneau est repliable (TitledPane).
+ */
+public class FrontMatterPanel extends TitledPane {
+
+    private static ResourceBundle getMessages() {
+        return ResourceBundle.getBundle("i18n.messages", Locale.getDefault());
+    }
+
+    private final TextField titleField;
+    private final TextField authorField;
+    private final TextField createdAtField;
+    private final TextField tagsField;
+    private final TextField summaryField;
+    private final CheckBox draftCheck;
+
+    private Runnable onChanged;
+
+    public FrontMatterPanel() {
+        setText(getMessages().getString("frontmatter.title"));
+        setCollapsible(true);
+        setExpanded(true);
+        getStyleClass().add("front-matter-panel");
+
+        GridPane grid = new GridPane();
+        grid.setHgap(8);
+        grid.setVgap(6);
+        grid.setPadding(new Insets(8));
+
+        // Contraintes de colonnes : label fixe, champ extensible
+        ColumnConstraints labelCol = new ColumnConstraints();
+        labelCol.setMinWidth(100);
+        ColumnConstraints fieldCol = new ColumnConstraints();
+        fieldCol.setHgrow(Priority.ALWAYS);
+        grid.getColumnConstraints().addAll(labelCol, fieldCol);
+
+        int row = 0;
+
+        // Title
+        Label titleLabel = new Label(getMessages().getString("frontmatter.field.title"));
+        titleField = new TextField();
+        titleField.setPromptText(getMessages().getString("frontmatter.field.title.prompt"));
+        titleField.textProperty().addListener((o, ov, nv) -> fireChanged());
+        grid.add(titleLabel, 0, row);
+        grid.add(titleField, 1, row);
+        row++;
+
+        // Author
+        Label authorLabel = new Label(getMessages().getString("frontmatter.field.author"));
+        authorField = new TextField();
+        authorField.setPromptText(getMessages().getString("frontmatter.field.author.prompt"));
+        authorField.textProperty().addListener((o, ov, nv) -> fireChanged());
+        grid.add(authorLabel, 0, row);
+        grid.add(authorField, 1, row);
+        row++;
+
+        // Created at
+        Label createdAtLabel = new Label(getMessages().getString("frontmatter.field.created_at"));
+        createdAtField = new TextField();
+        createdAtField.setPromptText("YYYY-MM-DD (HH:mm)");
+        createdAtField.textProperty().addListener((o, ov, nv) -> fireChanged());
+        grid.add(createdAtLabel, 0, row);
+        grid.add(createdAtField, 1, row);
+        row++;
+
+        // Tags
+        Label tagsLabel = new Label(getMessages().getString("frontmatter.field.tags"));
+        tagsField = new TextField();
+        tagsField.setPromptText(getMessages().getString("frontmatter.field.tags.prompt"));
+        tagsField.textProperty().addListener((o, ov, nv) -> fireChanged());
+        grid.add(tagsLabel, 0, row);
+        grid.add(tagsField, 1, row);
+        row++;
+
+        // Summary
+        Label summaryLabel = new Label(getMessages().getString("frontmatter.field.summary"));
+        summaryField = new TextField();
+        summaryField.setPromptText(getMessages().getString("frontmatter.field.summary.prompt"));
+        summaryField.textProperty().addListener((o, ov, nv) -> fireChanged());
+        grid.add(summaryLabel, 0, row);
+        grid.add(summaryField, 1, row);
+        row++;
+
+        // Draft
+        Label draftLabel = new Label(getMessages().getString("frontmatter.field.draft"));
+        draftCheck = new CheckBox();
+        draftCheck.setTooltip(new Tooltip(getMessages().getString("frontmatter.field.draft.tooltip")));
+        draftCheck.selectedProperty().addListener((o, ov, nv) -> fireChanged());
+        grid.add(draftLabel, 0, row);
+        grid.add(draftCheck, 1, row);
+
+        setContent(grid);
+    }
+
+    // ── Public API ──────────────────────────────────────────────
+
+    /**
+     * Remplit le panneau avec les données d'un objet FrontMatter.
+     *
+     * @param fm le front matter (peut être null pour un front matter vide)
+     */
+    public void setFrontMatter(FrontMatter fm) {
+        if (fm == null) {
+            clear();
+            return;
+        }
+        titleField.setText(fm.getTitle());
+        authorField.setText(fm.getAuthorsAsString());
+        createdAtField.setText(fm.getCreatedAt());
+        tagsField.setText(fm.getTagsAsString());
+        summaryField.setText(fm.getSummary());
+        draftCheck.setSelected(fm.isDraft());
+    }
+
+    /**
+     * Construit un objet FrontMatter à partir des valeurs des champs.
+     *
+     * @return le front matter courant
+     */
+    public FrontMatter getFrontMatter() {
+        FrontMatter fm = new FrontMatter();
+        fm.setTitle(titleField.getText().trim());
+        fm.setAuthorsFromString(authorField.getText().trim());
+        fm.setCreatedAt(createdAtField.getText().trim());
+        fm.setTagsFromString(tagsField.getText().trim());
+        fm.setSummary(summaryField.getText().trim());
+        fm.setDraft(draftCheck.isSelected());
+        return fm;
+    }
+
+    /**
+     * Efface tous les champs.
+     */
+    public void clear() {
+        titleField.clear();
+        authorField.clear();
+        createdAtField.clear();
+        tagsField.clear();
+        summaryField.clear();
+        draftCheck.setSelected(false);
+    }
+
+    /**
+     * Initialise un front matter par défaut avec la date du jour.
+     */
+    public void initDefaults() {
+        createdAtField.setText(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+    }
+
+    /**
+     * Définit le callback déclenché lorsqu'un champ est modifié.
+     */
+    public void setOnChanged(Runnable onChanged) {
+        this.onChanged = onChanged;
+    }
+
+    // ── Privé ───────────────────────────────────────────────────
+
+    private void fireChanged() {
+        if (onChanged != null) {
+            onChanged.run();
+        }
+    }
+}

--- a/src/main/java/utils/FrontMatter.java
+++ b/src/main/java/utils/FrontMatter.java
@@ -1,0 +1,277 @@
+package utils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Modèle représentant les métadonnées "Front Matter" d'un document Markdown.
+ * <p>
+ * Format attendu en tête de fichier :
+ * <pre>
+ * ---
+ * title: Mon article
+ * author: Jean Dupont
+ * created_at: 2026-02-21
+ * tags: [java, markdown, editor]
+ * summary: Un résumé de l'article
+ * draft: true
+ * ---
+ * </pre>
+ */
+public class FrontMatter {
+
+    // ── Format de date ──────────────────────────────────────────
+    private static final DateTimeFormatter DATE_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter DATETIME_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    /** Pattern pour détecter un bloc front matter au début du fichier. */
+    private static final Pattern FM_BLOCK =
+            Pattern.compile("\\A---\\s*\\n(.*?)\\n---\\s*\\n?", Pattern.DOTALL);
+
+    /** Pattern pour parser une liste entre crochets. */
+    private static final Pattern LIST_PATTERN =
+            Pattern.compile("\\[(.*)\\]");
+
+    // ── Champs ──────────────────────────────────────────────────
+    private String title = "";
+    private List<String> authors = new ArrayList<>();
+    private String createdAt = "";
+    private List<String> tags = new ArrayList<>();
+    private String summary = "";
+    private boolean draft = false;
+
+    // ── Constructeurs ───────────────────────────────────────────
+
+    public FrontMatter() {
+    }
+
+    // ── Parsing ─────────────────────────────────────────────────
+
+    /**
+     * Analyse le contenu d'un fichier Markdown et en extrait le front matter.
+     *
+     * @param content le contenu complet du fichier
+     * @return le FrontMatter parsé, ou {@code null} si aucun bloc n'est détecté
+     */
+    public static FrontMatter parse(String content) {
+        if (content == null) return null;
+        Matcher m = FM_BLOCK.matcher(content);
+        if (!m.find()) return null;
+
+        FrontMatter fm = new FrontMatter();
+        String block = m.group(1);
+
+        for (String line : block.split("\\n")) {
+            int colon = line.indexOf(':');
+            if (colon < 0) continue;
+            String key = line.substring(0, colon).trim().toLowerCase();
+            String value = line.substring(colon + 1).trim();
+            switch (key) {
+                case "title" -> fm.title = value;
+                case "author" -> fm.authors = parseList(value);
+                case "created_at" -> fm.createdAt = value;
+                case "tags" -> fm.tags = parseList(value);
+                case "summary" -> fm.summary = value;
+                case "draft" -> fm.draft = Boolean.parseBoolean(value);
+            }
+        }
+        return fm;
+    }
+
+    /**
+     * Retourne le contenu du fichier sans le bloc front matter.
+     *
+     * @param content le contenu complet
+     * @return le contenu Markdown pur (après le bloc ---)
+     */
+    public static String stripFrontMatter(String content) {
+        if (content == null) return "";
+        Matcher m = FM_BLOCK.matcher(content);
+        if (m.find()) {
+            return content.substring(m.end());
+        }
+        return content;
+    }
+
+    /**
+     * Sérialise le front matter en bloc YAML.
+     *
+     * @return le bloc front matter (avec les délimiteurs ---)
+     */
+    public String serialize() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("---\n");
+        if (!title.isBlank()) {
+            sb.append("title: ").append(title).append('\n');
+        }
+        if (!authors.isEmpty()) {
+            sb.append("author: ").append(formatList(authors)).append('\n');
+        }
+        if (!createdAt.isBlank()) {
+            sb.append("created_at: ").append(createdAt).append('\n');
+        }
+        if (!tags.isEmpty()) {
+            sb.append("tags: ").append(formatList(tags)).append('\n');
+        }
+        if (!summary.isBlank()) {
+            sb.append("summary: ").append(summary).append('\n');
+        }
+        if (draft) {
+            sb.append("draft: true\n");
+        }
+        sb.append("---\n");
+        return sb.toString();
+    }
+
+    /**
+     * Indique si le front matter est entièrement vide (aucun champ renseigné).
+     */
+    public boolean isEmpty() {
+        return title.isBlank()
+                && authors.isEmpty()
+                && createdAt.isBlank()
+                && tags.isEmpty()
+                && summary.isBlank()
+                && !draft;
+    }
+
+    // ── Helpers privés ──────────────────────────────────────────
+
+    /**
+     * Parse une valeur qui peut être :
+     * <ul>
+     *   <li>un scalaire simple : {@code "Jean Dupont"}</li>
+     *   <li>une liste entre crochets : {@code "[a, b, c]"}</li>
+     * </ul>
+     */
+    private static List<String> parseList(String value) {
+        if (value == null || value.isBlank()) return new ArrayList<>();
+        Matcher m = LIST_PATTERN.matcher(value);
+        if (m.find()) {
+            String inner = m.group(1);
+            List<String> items = new ArrayList<>();
+            for (String item : inner.split(",")) {
+                String trimmed = item.trim();
+                if (!trimmed.isEmpty()) items.add(trimmed);
+            }
+            return items;
+        }
+        // Valeur scalaire → liste à un élément
+        return new ArrayList<>(List.of(value.trim()));
+    }
+
+    /**
+     * Formate une liste en représentation YAML inline.
+     */
+    private static String formatList(List<String> items) {
+        if (items.size() == 1) return items.get(0);
+        return "[" + String.join(", ", items) + "]";
+    }
+
+    // ── Getters / Setters ───────────────────────────────────────
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title != null ? title : "";
+    }
+
+    public List<String> getAuthors() {
+        return Collections.unmodifiableList(authors);
+    }
+
+    public void setAuthors(List<String> authors) {
+        this.authors = authors != null ? new ArrayList<>(authors) : new ArrayList<>();
+    }
+
+    /**
+     * Définit les auteurs à partir d'une chaîne séparée par des virgules.
+     */
+    public void setAuthorsFromString(String authorsStr) {
+        this.authors = parseList(authorsStr);
+    }
+
+    /**
+     * Retourne les auteurs sous forme de chaîne séparée par des virgules.
+     */
+    public String getAuthorsAsString() {
+        return String.join(", ", authors);
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt != null ? createdAt : "";
+    }
+
+    public List<String> getTags() {
+        return Collections.unmodifiableList(tags);
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags != null ? new ArrayList<>(tags) : new ArrayList<>();
+    }
+
+    /**
+     * Définit les tags à partir d'une chaîne séparée par des virgules.
+     */
+    public void setTagsFromString(String tagsStr) {
+        this.tags = parseList("[" + tagsStr + "]");
+    }
+
+    /**
+     * Retourne les tags sous forme de chaîne séparée par des virgules.
+     */
+    public String getTagsAsString() {
+        return String.join(", ", tags);
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary != null ? summary : "";
+    }
+
+    public boolean isDraft() {
+        return draft;
+    }
+
+    public void setDraft(boolean draft) {
+        this.draft = draft;
+    }
+
+    /**
+     * Valide le format de la date created_at.
+     *
+     * @return true si la date est vide ou au format valide (YYYY-MM-DD ou YYYY-MM-DD HH:mm)
+     */
+    public boolean isCreatedAtValid() {
+        if (createdAt.isBlank()) return true;
+        try {
+            DATETIME_FMT.parse(createdAt);
+            return true;
+        } catch (DateTimeParseException e1) {
+            try {
+                DATE_FMT.parse(createdAt);
+                return true;
+            } catch (DateTimeParseException e2) {
+                return false;
+            }
+        }
+    }
+}

--- a/src/main/resources/css/themes/dark.css
+++ b/src/main/resources/css/themes/dark.css
@@ -372,3 +372,32 @@
     -fx-text-fill: #555555;
     -fx-font-size: 10px;
 }
+
+/* === Front Matter Panel === */
+.front-matter-panel {
+    -fx-border-color: #404040;
+    -fx-border-width: 0 0 1 0;
+}
+
+.front-matter-panel > .title {
+    -fx-background-color: #333333;
+    -fx-font-weight: bold;
+    -fx-font-size: 11px;
+}
+
+.front-matter-panel > .content {
+    -fx-background-color: #2b2b2b;
+}
+
+.front-matter-panel .label {
+    -fx-text-fill: #bbbbbb;
+    -fx-font-size: 12px;
+}
+
+.front-matter-panel .text-field {
+    -fx-background-color: #383838;
+    -fx-text-fill: #e0e0e0;
+    -fx-border-color: #505050;
+    -fx-border-radius: 3px;
+    -fx-font-size: 12px;
+}

--- a/src/main/resources/css/themes/high-contrast.css
+++ b/src/main/resources/css/themes/high-contrast.css
@@ -357,3 +357,33 @@
     -fx-text-fill: #ffff00;
     -fx-font-size: 10px;
 }
+
+/* === Front Matter Panel === */
+.front-matter-panel {
+    -fx-border-color: #ffffff;
+    -fx-border-width: 0 0 2 0;
+}
+
+.front-matter-panel > .title {
+    -fx-background-color: #000000;
+    -fx-text-fill: #ffff00;
+    -fx-font-weight: bold;
+    -fx-font-size: 11px;
+}
+
+.front-matter-panel > .content {
+    -fx-background-color: #000000;
+}
+
+.front-matter-panel .label {
+    -fx-text-fill: #ffffff;
+    -fx-font-size: 12px;
+}
+
+.front-matter-panel .text-field {
+    -fx-background-color: #1a1a1a;
+    -fx-text-fill: #ffffff;
+    -fx-border-color: #ffffff;
+    -fx-border-radius: 3px;
+    -fx-font-size: 12px;
+}

--- a/src/main/resources/css/themes/light.css
+++ b/src/main/resources/css/themes/light.css
@@ -278,3 +278,31 @@
     -fx-text-fill: #aaaaaa;
     -fx-font-size: 10px;
 }
+
+/* === Front Matter Panel === */
+.front-matter-panel {
+    -fx-border-color: #deddda;
+    -fx-border-width: 0 0 1 0;
+}
+
+.front-matter-panel > .title {
+    -fx-background-color: #f0efee;
+    -fx-font-weight: bold;
+    -fx-font-size: 11px;
+}
+
+.front-matter-panel > .content {
+    -fx-background-color: #fafaf9;
+}
+
+.front-matter-panel .label {
+    -fx-text-fill: #555555;
+    -fx-font-size: 12px;
+}
+
+.front-matter-panel .text-field {
+    -fx-background-color: #ffffff;
+    -fx-border-color: #deddda;
+    -fx-border-radius: 3px;
+    -fx-font-size: 12px;
+}

--- a/src/main/resources/css/themes/solarized-dark.css
+++ b/src/main/resources/css/themes/solarized-dark.css
@@ -289,3 +289,32 @@
     -fx-text-fill: #586e75;
     -fx-font-size: 10px;
 }
+
+/* === Front Matter Panel === */
+.front-matter-panel {
+    -fx-border-color: #073642;
+    -fx-border-width: 0 0 1 0;
+}
+
+.front-matter-panel > .title {
+    -fx-background-color: #073642;
+    -fx-font-weight: bold;
+    -fx-font-size: 11px;
+}
+
+.front-matter-panel > .content {
+    -fx-background-color: #002b36;
+}
+
+.front-matter-panel .label {
+    -fx-text-fill: #93a1a1;
+    -fx-font-size: 12px;
+}
+
+.front-matter-panel .text-field {
+    -fx-background-color: #073642;
+    -fx-text-fill: #93a1a1;
+    -fx-border-color: #586e75;
+    -fx-border-radius: 3px;
+    -fx-font-size: 12px;
+}

--- a/src/main/resources/css/themes/solarized-light.css
+++ b/src/main/resources/css/themes/solarized-light.css
@@ -262,3 +262,32 @@
     -fx-text-fill: #93a1a1;
     -fx-font-size: 10px;
 }
+
+/* === Front Matter Panel === */
+.front-matter-panel {
+    -fx-border-color: #eee8d5;
+    -fx-border-width: 0 0 1 0;
+}
+
+.front-matter-panel > .title {
+    -fx-background-color: #eee8d5;
+    -fx-font-weight: bold;
+    -fx-font-size: 11px;
+}
+
+.front-matter-panel > .content {
+    -fx-background-color: #fdf6e3;
+}
+
+.front-matter-panel .label {
+    -fx-text-fill: #657b83;
+    -fx-font-size: 12px;
+}
+
+.front-matter-panel .text-field {
+    -fx-background-color: #fdf6e3;
+    -fx-text-fill: #586e75;
+    -fx-border-color: #eee8d5;
+    -fx-border-radius: 3px;
+    -fx-font-size: 12px;
+}

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -168,4 +168,18 @@ options.theme.delete.title=Supprimer le th\u00e8me
 options.theme.delete.header=Supprimer ce th\u00e8me personnalis\u00e9 ?
 options.theme.delete.content=Le fichier CSS sera d\u00e9finitivement supprim\u00e9.
 options.theme.error.title=Erreur
+
+# Front Matter
+frontmatter.title=Front Matter
+frontmatter.field.title=Titre :
+frontmatter.field.title.prompt=Titre de l'article
+frontmatter.field.author=Auteur(s) :
+frontmatter.field.author.prompt=Auteur ou liste d'auteurs (s\u00e9par\u00e9s par des virgules)
+frontmatter.field.created_at=Date :
+frontmatter.field.tags=Tags :
+frontmatter.field.tags.prompt=tag1, tag2, tag3
+frontmatter.field.summary=R\u00e9sum\u00e9 :
+frontmatter.field.summary.prompt=R\u00e9sum\u00e9 de l'article (optionnel)
+frontmatter.field.draft=Brouillon :
+frontmatter.field.draft.tooltip=Cocher si la note n'est pas encore publi\u00e9e
 options.theme.error.create=Impossible de cr\u00e9er le th\u00e8me

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -171,3 +171,17 @@ options.theme.delete.title=Thema löschen
 options.theme.delete.header=Dieses benutzerdefinierte Thema löschen?
 options.theme.delete.content=Die CSS-Datei wird dauerhaft gelöscht.
 options.theme.error.title=Fehler
+
+# Front Matter
+frontmatter.title=Front Matter
+frontmatter.field.title=Titel:
+frontmatter.field.title.prompt=Artikeltitel
+frontmatter.field.author=Autor(en):
+frontmatter.field.author.prompt=Autor oder kommagetrennte Autorenliste
+frontmatter.field.created_at=Datum:
+frontmatter.field.tags=Tags:
+frontmatter.field.tags.prompt=tag1, tag2, tag3
+frontmatter.field.summary=Zusammenfassung:
+frontmatter.field.summary.prompt=Zusammenfassung des Artikels (optional)
+frontmatter.field.draft=Entwurf:
+frontmatter.field.draft.tooltip=Aktivieren, wenn die Notiz noch nicht veröffentlicht ist

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -171,3 +171,17 @@ options.theme.delete.title=Delete theme
 options.theme.delete.header=Delete this custom theme?
 options.theme.delete.content=The CSS file will be permanently deleted.
 options.theme.error.title=Error
+
+# Front Matter
+frontmatter.title=Front Matter
+frontmatter.field.title=Title:
+frontmatter.field.title.prompt=Article title
+frontmatter.field.author=Author(s):
+frontmatter.field.author.prompt=Author or comma-separated list of authors
+frontmatter.field.created_at=Date:
+frontmatter.field.tags=Tags:
+frontmatter.field.tags.prompt=tag1, tag2, tag3
+frontmatter.field.summary=Summary:
+frontmatter.field.summary.prompt=Article summary (optional)
+frontmatter.field.draft=Draft:
+frontmatter.field.draft.tooltip=Check if the note is not yet published

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -170,3 +170,17 @@ options.theme.delete.title=Eliminar tema
 options.theme.delete.header=¿Eliminar este tema personalizado?
 options.theme.delete.content=El archivo CSS será eliminado permanentemente.
 options.theme.error.title=Error
+
+# Front Matter
+frontmatter.title=Front Matter
+frontmatter.field.title=Título:
+frontmatter.field.title.prompt=Título del artículo
+frontmatter.field.author=Autor(es):
+frontmatter.field.author.prompt=Autor o lista de autores separados por comas
+frontmatter.field.created_at=Fecha:
+frontmatter.field.tags=Etiquetas:
+frontmatter.field.tags.prompt=etiqueta1, etiqueta2, etiqueta3
+frontmatter.field.summary=Resumen:
+frontmatter.field.summary.prompt=Resumen del artículo (opcional)
+frontmatter.field.draft=Borrador:
+frontmatter.field.draft.tooltip=Marcar si la nota aún no está publicada

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -171,3 +171,17 @@ options.theme.delete.title=Supprimer le thème
 options.theme.delete.header=Supprimer ce thème personnalisé ?
 options.theme.delete.content=Le fichier CSS sera définitivement supprimé.
 options.theme.error.title=Erreur
+
+# Front Matter
+frontmatter.title=Front Matter
+frontmatter.field.title=Titre :
+frontmatter.field.title.prompt=Titre de l'article
+frontmatter.field.author=Auteur(s) :
+frontmatter.field.author.prompt=Auteur ou liste d'auteurs (séparés par des virgules)
+frontmatter.field.created_at=Date :
+frontmatter.field.tags=Tags :
+frontmatter.field.tags.prompt=tag1, tag2, tag3
+frontmatter.field.summary=Résumé :
+frontmatter.field.summary.prompt=Résumé de l'article (optionnel)
+frontmatter.field.draft=Brouillon :
+frontmatter.field.draft.tooltip=Cocher si la note n'est pas encore publiée

--- a/src/main/resources/i18n/messages_it.properties
+++ b/src/main/resources/i18n/messages_it.properties
@@ -170,3 +170,17 @@ options.theme.delete.title=Elimina tema
 options.theme.delete.header=Eliminare questo tema personalizzato?
 options.theme.delete.content=Il file CSS verrà eliminato permanentemente.
 options.theme.error.title=Errore
+
+# Front Matter
+frontmatter.title=Front Matter
+frontmatter.field.title=Titolo:
+frontmatter.field.title.prompt=Titolo dell'articolo
+frontmatter.field.author=Autore/i:
+frontmatter.field.author.prompt=Autore o lista di autori separati da virgole
+frontmatter.field.created_at=Data:
+frontmatter.field.tags=Tag:
+frontmatter.field.tags.prompt=tag1, tag2, tag3
+frontmatter.field.summary=Riepilogo:
+frontmatter.field.summary.prompt=Riepilogo dell'articolo (opzionale)
+frontmatter.field.draft=Bozza:
+frontmatter.field.draft.tooltip=Selezionare se la nota non è ancora pubblicata


### PR DESCRIPTION
- Implemented a new Front Matter panel for editing metadata such as title, author, created_at, tags, summary, and draft status.
- Updated DocumentTab to parse and display Front Matter, integrating it with the editor and preview.
- Enhanced PreviewPanel to render Front Matter metadata in the preview.
- Modified ProjectExplorerPanel to display Front Matter titles in the project explorer for Markdown files.
- Added utility class FrontMatter for parsing and serializing Front Matter data.
- Updated CSS themes to style the Front Matter panel appropriately.
- Localized new Front Matter fields in multiple languages (English, French, German, Spanish, Italian).

fixes #12