### PR TITLE
Add reading mode (View > Enter Reading Mode / Mode lecture)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,11 +6,20 @@
     "configurations": [
         {
             "type": "java",
+            "name": "MarkNote",
+            "request": "launch",
+            "mainClass": "MarkNote",
+            "projectName": "marknote"
+        },
+        {
+            "type": "java",
             "name": "Main",
             "request": "launch",
             "mainClass": "Main",
             "projectName": "marknote",
-            "args":["--console-debug"]
+            "args": [
+                "--console-debug"
+            ]
         },
         {
             "type": "java",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,5 @@
     ],
     "java.project.outputPath": "target/classes",
     "java.format.settings.url": ".vscode/java-formatter.xml",
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A lightweight and modern Markdown editor built with JavaFX.
 - **Welcome Page** - Configurable welcome screen with recent projects
 - **Cross-platform** - Works on Linux, macOS, and Windows
 - **Application Icon** - Custom SVG icon with PNG exports (16, 32, 64, 128 px) shown in the title bar, taskbar, and Alt+Tab switcher
+- **Reading Mode** - Distraction-free fullscreen reading (`Ctrl+Shift+P` or **View → Enter Reading Mode**): the Preview panel fills the whole screen, the editor and all side panels are hidden; the Project Explorer reappears as a compact floating overlay with a **▾/▴ minimize toggle** to collapse it to its title bar; exiting restores all panels and split-divider positions exactly as they were before
 - **View Menu Controls** - Toggle visibility of Project Explorer (`Ctrl+E`), Preview (`Ctrl+P`), Tag Cloud (`Ctrl+T`), Network Diagram (`Ctrl+L`), and **LLM Chat** (`Ctrl+M`) via the View menu; Show Welcome
 - **Close Tab** - Close the active document tab with `Ctrl+W`
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
       <name>Frédéric Delorme</name>
       <email>contact.snapgames@gmail.com</email>
     </developer>
+     <developer>
+      <name>Jean-Baptiste Meyer</name>
+      <email>unfixed11_scarab@icloud.com</email>
+    </developer>
   </developers>
 
   <!-- ═══════════════════════════════════════════════════════════════════════
@@ -52,6 +56,9 @@
     <app.main.class>Main</app.main.class>
     <app.jvm.options>-Djava.net.preferIPv6Addresses=true -Xmx512m</app.jvm.options>
     <javafx.modules>javafx.base,javafx.graphics,javafx.controls,javafx.fxml,javafx.media,javafx.web</javafx.modules>
+
+    <!-- Fallback used when the git plugin cannot read the repo (e.g. read-only .git) -->
+    <git.commit.id.abbrev>local</git.commit.id.abbrev>
 
     <!-- jpackage / installer metadata -->
     <!-- Version used by jpackage: overridden in mac profiles because macOS
@@ -143,6 +150,8 @@
         <configuration>
           <generateGitPropertiesFile>false</generateGitPropertiesFile>
           <abbrevLength>12</abbrevLength>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+          <useNativeGit>true</useNativeGit>
         </configuration>
       </plugin>
 
@@ -281,17 +290,9 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>${app.jvm.options}</argument>
-            <argument>--module-path</argument>
-            <argument>${project.build.directory}/dependency</argument>
-            <argument>--add-modules</argument>
-            <argument>${javafx.modules}</argument>
-            <argument>-cp</argument>
-            <argument>${project.build.directory}/build/${project.name}-${project.version}-${git.commit.id.abbrev}.jar</argument>
-            <argument>${app.main.class}</argument>
-          </arguments>
+          <executable>${java.home}/bin/java</executable>
+          <workingDirectory>${project.basedir}</workingDirectory>
+          <commandlineArgs>-Djava.net.preferIPv6Addresses=true -Xmx512m --module-path target/dependency --add-modules ${javafx.modules} -cp target/classes:target/dependency/* ${app.main.class}</commandlineArgs>
         </configuration>
       </plugin>
 

--- a/src/docs/user-guide-en.md
+++ b/src/docs/user-guide-en.md
@@ -31,12 +31,13 @@ Welcome to MarkNote, a lightweight and modern Markdown editor built with JavaFX.
 11. [Network Diagram](#network-diagram)
 12. [Status Bar](#status-bar)
 13. [Live Preview](#live-preview)
-14. [LLM Chat](#llm-chat)
-15. [Splash Screen & About](#splash-screen--about)
-16. [Themes](#themes)
-17. [Options & Settings](#options--settings)
-18. [Keyboard Shortcuts](#keyboard-shortcuts)
-19. [Troubleshooting](#troubleshooting)
+14. [Reading Mode](#reading-mode)
+15. [LLM Chat](#llm-chat)
+16. [Splash Screen & About](#splash-screen--about)
+17. [Themes](#themes)
+18. [Options & Settings](#options--settings)
+19. [Keyboard Shortcuts](#keyboard-shortcuts)
+20. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -74,6 +75,7 @@ MarkNote is a cross-platform Markdown editor designed for writers, developers, a
 - **Project Session Restore** - Open documents are automatically saved when you close a project and restored when you reopen it; the session is stored in a `.marknote` file at the project root
 - **Scroll Synchronization** - The editor and preview panels scroll in sync so that the rendered output always reflects the text at the cursor position
 - **Drag & Drop** - Drop files into the editor to insert Markdown links or images
+- **Reading Mode** - Distraction-free fullscreen reading with the preview panel filling the screen; the Project Explorer floats as a compact overlay with a minimize toggle; all other panels are hidden and fully restored on exit (`Ctrl+Shift+P`)
 - **Multi-language Support** - Available in 5 languages
 
 ---
@@ -193,6 +195,7 @@ You can show or hide panels using the **View** menu or by clicking the **×** cl
 | **View → Tag Cloud** (`Ctrl+T`) | Toggle the Tag Cloud sub-panel |
 | **View → Network Diagram** (`Ctrl+L`) | Toggle the Network Diagram sub-panel |
 | **View → LLM Chat** (`Ctrl+M`) | Toggle the LLM Chat panel when the feature is enabled |
+| **View → Enter Reading Mode** (`Ctrl+Shift+P`) | Enter distraction-free fullscreen reading mode |
 | **View → Show Welcome** | Open the Welcome tab |
 
 Each panel can also be closed by clicking the **×** button in its header. Re-opening it from the View menu restores it to the layout.
@@ -992,6 +995,50 @@ You can also specify only width or only height:
 
 ---
 
+## Reading Mode
+
+Reading Mode provides a distraction-free, fullscreen environment for reading and reviewing your documents without any editing UI in the way.
+
+### Entering Reading Mode
+
+| Method | Description |
+|--------|-------------|
+| **View → Enter Reading Mode** | Menu item in the View menu |
+| `Ctrl+Shift+P` | Keyboard shortcut |
+
+When reading mode is activated:
+- The application goes **fullscreen**
+- All side panels (Project Explorer, Tag Cloud, Network Diagram, LLM Chat) are **hidden**
+- The **editor tab bar** is removed from the layout
+- The **Preview panel** expands to fill the entire screen
+- The **menu bar** is replaced by a thin bar containing only an **Exit Reading Mode** button
+- The **Project Explorer** reappears as a compact **floating overlay** panel pinned to the top-left corner of the screen
+
+### The Floating Project Explorer
+
+In reading mode, the Project Explorer stays accessible as a floating panel so you can navigate between files without leaving the reader:
+
+| Control | Description |
+|---------|-------------|
+| **▾ minimize button** | Collapses the panel to just its title bar, clearing the reading area |
+| **▴ maximize button** | Restores the full panel after minimizing |
+
+The **close (×)** and **detach (⇱)** buttons are hidden in reading mode — the panel is always visible and cannot be closed or detached while reading.
+
+### Exiting Reading Mode
+
+| Method | Description |
+|--------|-------------|
+| **Exit Reading Mode** button | Click the button in the top-right bar |
+| `Escape` / exit fullscreen | Exiting fullscreen (F11 on Linux/Windows, `Cmd+Ctrl+F` on macOS) also exits reading mode |
+
+When reading mode exits:
+- All panels that were visible before are **restored** to their original docked positions
+- The **split divider positions** (panel widths, editor/preview ratio) are fully restored to what they were before entering reading mode
+- The editor tab bar and the menu bar return
+
+---
+
 ## LLM Chat
 
 MarkNote can connect to a local or remote Large Language Model and provide an integrated chat workflow alongside your notes.
@@ -1363,6 +1410,7 @@ To change the language:
 | `Ctrl+T` | Toggle Tag Cloud |
 | `Ctrl+L` | Toggle Network Diagram |
 | `Ctrl+M` | Toggle LLM Chat |
+| `Ctrl+Shift+P` | Enter Reading Mode |
 
 > **Note:** On macOS, use `Cmd` instead of `Ctrl`.
 

--- a/src/main/java/MarkNote.java
+++ b/src/main/java/MarkNote.java
@@ -42,6 +42,7 @@ import javafx.geometry.Orientation;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.Menu;
@@ -59,7 +60,9 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 
 /**
  * Application principale MarkNote - Éditeur Markdown.
@@ -80,6 +83,11 @@ public class MarkNote extends Application {
     private AppConfig config;
     private Menu recentMenu;
 
+    // Layout racine et barre du haut (champs pour le mode lecture)
+    private BorderPane root;
+    private HBox topBar;
+    private HBox exitReadingModeBar;
+
     // Panels et SplitPanes pour la gestion de l'affichage
     private SplitPane editorSplit;
     private DockingManager dockingManager;
@@ -99,6 +107,13 @@ public class MarkNote extends Application {
     private final Map<BasePanel, Boolean> lastDockedState = new HashMap<>();
     private final Map<BasePanel, CheckMenuItem> panelMenuItems = new HashMap<>();
     private boolean syncingPanelMenuState = false;
+
+    // Mode lecture
+    private boolean readingModeActive = false;
+    private final Map<BasePanel, Boolean> readingModePanelVisibility = new HashMap<>();
+    private boolean readingModePreviewVisible;
+    private double readingModeEditorSplitDivider = 0.5;
+    private Stage readingModeFloatingStage;
 
     public static void main(String[] args) {
         // Prefer IPv6 when both IPv4/IPv6 exist for the same host.
@@ -138,7 +153,7 @@ public class MarkNote extends Application {
     public void start(Stage stage) {
         this.primaryStage = stage;
 
-        BorderPane root = new BorderPane();
+        root = new BorderPane();
 
         // TabPane pour les documents
         mainTabPane = new TabPane();
@@ -317,11 +332,28 @@ public class MarkNote extends Application {
         MenuBar menuBar = createMenuBar();
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
-        HBox topBar = new HBox(menuBar, spacer, searchBox);
+        topBar = new HBox(menuBar, spacer, searchBox);
         topBar.getStyleClass().add("top-bar");
         topBar.setAlignment(javafx.geometry.Pos.CENTER_LEFT);
         HBox.setHgrow(menuBar, Priority.NEVER);
         root.setTop(topBar);
+
+        // Barre du mode lecture (remplace la barre de menu en mode lecture)
+        Button exitReadingBtn = new Button(messages.getString("reading.mode.exit"));
+        exitReadingBtn.setOnAction(e -> exitReadingMode());
+        Region exitSpacer = new Region();
+        HBox.setHgrow(exitSpacer, Priority.ALWAYS);
+        exitReadingModeBar = new HBox(exitSpacer, exitReadingBtn);
+        exitReadingModeBar.getStyleClass().add("top-bar");
+        exitReadingModeBar.setAlignment(javafx.geometry.Pos.CENTER_RIGHT);
+        exitReadingModeBar.setPadding(new javafx.geometry.Insets(4, 8, 4, 8));
+
+        // Listener pour gérer la sortie du mode plein écran via Echap
+        primaryStage.fullScreenProperty().addListener((obs, wasFS, isFS) -> {
+            if (readingModeActive && !isFS) {
+                exitReadingMode(false);
+            }
+        });
 
         Scene scene = new Scene(root, 1200, 700);
         applyTheme(scene);
@@ -466,7 +498,10 @@ public class MarkNote extends Application {
             viewMenu.getItems().add(showLLMPanelMenuItem);
         }
         
-        viewMenu.getItems().addAll(new SeparatorMenuItem(), showWelcomeItem);
+        MenuItem enterReadingModeItem = new MenuItem(messages.getString("menu.view.readingMode"));
+        enterReadingModeItem.setOnAction(e -> enterReadingMode());
+
+        viewMenu.getItems().addAll(new SeparatorMenuItem(), enterReadingModeItem, new SeparatorMenuItem(), showWelcomeItem);
 
         // Option Console (uniquement si --console-debug est actif)
         if (consoleDebugEnabled) {
@@ -759,6 +794,113 @@ public class MarkNote extends Application {
             detachedTab.hideWithoutDocking();
         } else if (dockingManager.isDocked(panel)) {
             dockingManager.hidePanel(panel);
+        }
+    }
+
+    private void enterReadingMode() {
+        if (readingModeActive) return;
+        readingModeActive = true;
+
+        // Sauvegarder l'état du panneau de preview et la position du diviseur
+        readingModePreviewVisible = editorSplit.getItems().contains(previewPanel);
+        if (!editorSplit.getDividers().isEmpty()) {
+            readingModeEditorSplitDivider = editorSplit.getDividers().get(0).getPosition();
+        }
+
+        // Sauvegarder la visibilité de tous les panneaux
+        readingModePanelVisibility.clear();
+        for (BasePanel panel : managedPanels.values()) {
+            readingModePanelVisibility.put(panel, isManagedPanelVisible(panel));
+        }
+
+        // Masquer tous les panneaux sauf l'explorateur de projet
+        for (BasePanel panel : managedPanels.values()) {
+            if (panel != projectExplorerPanel && isManagedPanelVisible(panel)) {
+                hideManagedPanel(panel);
+            }
+        }
+
+        // Retirer l'explorateur du layout principal et l'afficher en fenêtre flottante
+        if (isManagedPanelVisible(projectExplorerPanel)) {
+            hideManagedPanel(projectExplorerPanel);
+
+            // rebuildLayout() crée un nouveau SplitPane et orpheline l'ancien,
+            // mais le panel en reste enfant. Il faut l'en détacher explicitement
+            // avant de le placer comme racine d'une nouvelle Scene.
+            javafx.scene.Parent orphan = projectExplorerPanel.getParent();
+            if (orphan instanceof SplitPane sp) {
+                sp.getItems().remove(projectExplorerPanel);
+            } else if (orphan instanceof javafx.scene.layout.Pane pane) {
+                pane.getChildren().remove(projectExplorerPanel);
+            }
+
+            readingModeFloatingStage = new Stage();
+            readingModeFloatingStage.initOwner(primaryStage);
+            readingModeFloatingStage.initStyle(StageStyle.UTILITY);
+            readingModeFloatingStage.setTitle(messages.getString("menu.view.projectExplorer"));
+            readingModeFloatingStage.setAlwaysOnTop(true);
+
+            Scene floatingScene = new Scene(projectExplorerPanel, 260, 600);
+            applyTheme(floatingScene);
+            readingModeFloatingStage.setScene(floatingScene);
+
+            // Positionner en haut à gauche de l'écran principal
+            javafx.geometry.Rectangle2D screen = Screen.getPrimary().getVisualBounds();
+            readingModeFloatingStage.setX(screen.getMinX());
+            readingModeFloatingStage.setY(screen.getMinY());
+
+            readingModeFloatingStage.show();
+        }
+
+        // Assurer que la preview est dans editorSplit et retirer l'éditeur
+        if (!editorSplit.getItems().contains(previewPanel)) {
+            editorSplit.getItems().add(previewPanel);
+        }
+        editorSplit.getItems().remove(mainTabPane);
+
+        // Passer en plein écran et remplacer la barre de menu
+        primaryStage.setFullScreenExitHint("");
+        primaryStage.setFullScreen(true);
+        root.setTop(exitReadingModeBar);
+    }
+
+    private void exitReadingMode() {
+        exitReadingMode(true);
+    }
+
+    private void exitReadingMode(boolean callSetFullScreen) {
+        if (!readingModeActive) return;
+        readingModeActive = false;
+
+        // Détacher l'explorateur de la scène flottante avant de le redocker
+        if (readingModeFloatingStage != null) {
+            readingModeFloatingStage.getScene().setRoot(new BorderPane());
+            readingModeFloatingStage.close();
+            readingModeFloatingStage = null;
+        }
+
+        // Restaurer la barre de menu et quitter le plein écran
+        root.setTop(topBar);
+        if (callSetFullScreen) {
+            primaryStage.setFullScreen(false);
+        }
+
+        // Restaurer editorSplit
+        if (!editorSplit.getItems().contains(mainTabPane)) {
+            editorSplit.getItems().add(0, mainTabPane);
+        }
+        if (!readingModePreviewVisible) {
+            editorSplit.getItems().remove(previewPanel);
+        }
+        if (editorSplit.getItems().size() > 1) {
+            editorSplit.setDividerPositions(readingModeEditorSplitDivider);
+        }
+
+        // Restaurer les panneaux qui étaient visibles
+        for (Map.Entry<BasePanel, Boolean> entry : readingModePanelVisibility.entrySet()) {
+            if (entry.getValue()) {
+                showManagedPanel(entry.getKey());
+            }
         }
     }
 

--- a/src/main/java/MarkNote.java
+++ b/src/main/java/MarkNote.java
@@ -113,7 +113,12 @@ public class MarkNote extends Application {
     private final Map<BasePanel, Boolean> readingModePanelVisibility = new HashMap<>();
     private boolean readingModePreviewVisible;
     private double readingModeEditorSplitDivider = 0.5;
+    private double[] readingModeDockingHDividers = new double[0];
+    private double[] readingModeDockingVDividers = new double[0];
     private Stage readingModeFloatingStage;
+    private double readingModeFloatingSavedHeight = 600;
+    // Center content of the explorer panel saved before minimizing in reading mode
+    private javafx.scene.Node readingModeExplorerCenter = null;
 
     public static void main(String[] args) {
         // Prefer IPv6 when both IPv4/IPv6 exist for the same host.
@@ -499,8 +504,9 @@ public class MarkNote extends Application {
         }
         
         MenuItem enterReadingModeItem = new MenuItem(messages.getString("menu.view.readingMode"));
+        enterReadingModeItem.setAccelerator(KeyCombination.keyCombination("Ctrl+Shift+P"));
         enterReadingModeItem.setOnAction(e -> enterReadingMode());
-
+  
         viewMenu.getItems().addAll(new SeparatorMenuItem(), enterReadingModeItem, new SeparatorMenuItem(), showWelcomeItem);
 
         // Option Console (uniquement si --console-debug est actif)
@@ -807,6 +813,10 @@ public class MarkNote extends Application {
             readingModeEditorSplitDivider = editorSplit.getDividers().get(0).getPosition();
         }
 
+        // Sauvegarder les positions des diviseurs du docking manager
+        readingModeDockingHDividers = dockingManager.getHorizontalDividers();
+        readingModeDockingVDividers = dockingManager.getVerticalDividers();
+
         // Sauvegarder la visibilité de tous les panneaux
         readingModePanelVisibility.clear();
         for (BasePanel panel : managedPanels.values()) {
@@ -849,7 +859,37 @@ public class MarkNote extends Application {
             readingModeFloatingStage.setX(screen.getMinX());
             readingModeFloatingStage.setY(screen.getMinY());
 
+            // Capture the center content now (before show) so we can restore it later
+            readingModeExplorerCenter = projectExplorerPanel.getCenter();
+            readingModeFloatingSavedHeight = 600;
+
             readingModeFloatingStage.show();
+
+            // Hide close/detach buttons; show minimize toggle
+            projectExplorerPanel.setCloseEnabled(false);
+            projectExplorerPanel.setDetachEnabled(false);
+            projectExplorerPanel.setMinimizeEnabled(true);
+            projectExplorerPanel.setMinimizedState(false);
+
+            projectExplorerPanel.setOnMinimize(() -> {
+                if (!projectExplorerPanel.isPanelMinimized()) {
+                    // Collapse: use the already-rendered header height (accurate since stage is shown).
+                    // Chrome height = OS title bar = stage total − scene content area.
+                    double headerH = projectExplorerPanel.getHeader().getHeight();
+                    double chromeH = readingModeFloatingStage.getHeight()
+                            - readingModeFloatingStage.getScene().getHeight();
+                    readingModeFloatingSavedHeight = readingModeFloatingStage.getHeight();
+                    projectExplorerPanel.setCenter(null);
+                    projectExplorerPanel.setMinimizedState(true);
+                    double collapsedH = headerH + chromeH;
+                    Platform.runLater(() -> readingModeFloatingStage.setHeight(collapsedH));
+                } else {
+                    // Expand: restore center then set stage back to saved height
+                    projectExplorerPanel.setCenter(readingModeExplorerCenter);
+                    projectExplorerPanel.setMinimizedState(false);
+                    Platform.runLater(() -> readingModeFloatingStage.setHeight(readingModeFloatingSavedHeight));
+                }
+            });
         }
 
         // Assurer que la preview est dans editorSplit et retirer l'éditeur
@@ -874,6 +914,17 @@ public class MarkNote extends Application {
 
         // Détacher l'explorateur de la scène flottante avant de le redocker
         if (readingModeFloatingStage != null) {
+            // Restore panel to full state before removing from floating stage
+            projectExplorerPanel.setOnMinimize(null);
+            projectExplorerPanel.setMinimizeEnabled(false);
+            projectExplorerPanel.setMinimizedState(false);
+            projectExplorerPanel.setCloseEnabled(true);
+            projectExplorerPanel.setDetachEnabled(true);
+            // If the panel was minimized its center was set to null; restore it
+            if (projectExplorerPanel.getCenter() == null && readingModeExplorerCenter != null) {
+                projectExplorerPanel.setCenter(readingModeExplorerCenter);
+            }
+            readingModeExplorerCenter = null;
             readingModeFloatingStage.getScene().setRoot(new BorderPane());
             readingModeFloatingStage.close();
             readingModeFloatingStage = null;
@@ -885,23 +936,33 @@ public class MarkNote extends Application {
             primaryStage.setFullScreen(false);
         }
 
-        // Restaurer editorSplit
+        // Restaurer editorSplit (items only — divider positions deferred below)
         if (!editorSplit.getItems().contains(mainTabPane)) {
             editorSplit.getItems().add(0, mainTabPane);
         }
         if (!readingModePreviewVisible) {
             editorSplit.getItems().remove(previewPanel);
         }
-        if (editorSplit.getItems().size() > 1) {
-            editorSplit.setDividerPositions(readingModeEditorSplitDivider);
-        }
 
-        // Restaurer les panneaux qui étaient visibles
+        // Restaurer les panneaux qui étaient visibles (chaque appel peut déclencher rebuildLayout)
         for (Map.Entry<BasePanel, Boolean> entry : readingModePanelVisibility.entrySet()) {
             if (entry.getValue()) {
                 showManagedPanel(entry.getKey());
             }
         }
+
+        // Restaurer les positions des diviseurs après que tous les rebuildLayout ont été faits.
+        // Platform.runLater garantit que les positions sont appliquées après le passage de layout.
+        final double savedEditorDivider = readingModeEditorSplitDivider;
+        final double[] savedHDividers = readingModeDockingHDividers;
+        final double[] savedVDividers = readingModeDockingVDividers;
+        Platform.runLater(() -> {
+            if (editorSplit.getItems().size() > 1) {
+                editorSplit.setDividerPositions(savedEditorDivider);
+            }
+            dockingManager.setHorizontalDividers(savedHDividers);
+            dockingManager.setVerticalDividers(savedVDividers);
+        });
     }
 
     private void saveManagedPanelStates() {

--- a/src/main/java/ui/BasePanel.java
+++ b/src/main/java/ui/BasePanel.java
@@ -27,11 +27,14 @@ public abstract class BasePanel extends BorderPane implements Detachable {
     private final Label titleLabel;
     private final Button closeButton;
     private final Button detachButton;
+    private final Button minimizeButton;
     private final HBox header;
     private final String titleKey;
 
     private Runnable onCloseAction;
     private Runnable onDetachAction;
+    private Runnable onMinimizeAction;
+    private boolean panelMinimized = false;
 
     /**
      * Crée un panel avec un bandeau contenant un titre et un bouton de fermeture.
@@ -70,8 +73,20 @@ public abstract class BasePanel extends BorderPane implements Detachable {
             }
         });
 
+        // Bouton réduire/agrandir (caché par défaut, activé en mode lecture)
+        minimizeButton = new Button("▾"); // ▾
+        minimizeButton.getStyleClass().add("panel-close-button");
+        minimizeButton.setTooltip(new Tooltip(getMessages().getString("panel.minimize.tooltip")));
+        minimizeButton.setVisible(false);
+        minimizeButton.setManaged(false);
+        minimizeButton.setOnAction(e -> {
+            if (onMinimizeAction != null) {
+                onMinimizeAction.run();
+            }
+        });
+
         // Header
-        header = new HBox(titleLabel, spacer, detachButton, closeButton);
+        header = new HBox(titleLabel, spacer, minimizeButton, detachButton, closeButton);
         header.setAlignment(Pos.CENTER_LEFT);
         header.setPadding(new Insets(4));
         header.getStyleClass().add("panel-header");
@@ -175,6 +190,27 @@ public abstract class BasePanel extends BorderPane implements Detachable {
 
     public String getPanelStateId() {
         return getClass().getSimpleName();
+    }
+
+    public void setMinimizeEnabled(boolean enabled) {
+        minimizeButton.setVisible(enabled);
+        minimizeButton.setManaged(enabled);
+    }
+
+    public void setOnMinimize(Runnable action) {
+        this.onMinimizeAction = action;
+    }
+
+    /** Updates the minimize button icon to reflect collapsed (true) or expanded (false) state. */
+    public void setMinimizedState(boolean minimized) {
+        panelMinimized = minimized;
+        minimizeButton.setText(minimized ? "▴" : "▾");
+        String tipKey = minimized ? "panel.maximize.tooltip" : "panel.minimize.tooltip";
+        minimizeButton.setTooltip(new Tooltip(getMessages().getString(tipKey)));
+    }
+
+    public boolean isPanelMinimized() {
+        return panelMinimized;
     }
 
     // ══════════════════════════════════════════════════════════════

--- a/src/main/java/ui/DetachedPanelTab.java
+++ b/src/main/java/ui/DetachedPanelTab.java
@@ -72,6 +72,9 @@ public class DetachedPanelTab extends Tab {
 
     public void hideWithoutDocking() {
         runCloseActionOnClose = false;
+        // Restore the panel's content before removing the tab so the panel
+        // is not left with a null center when shown again.
+        sourcePanel.onReattached(detachedContent);
         if (getTabPane() != null) {
             getTabPane().getTabs().remove(this);
         }

--- a/src/main/java/ui/DockingManager.java
+++ b/src/main/java/ui/DockingManager.java
@@ -206,13 +206,11 @@ public class DockingManager {
     }
 
     /**
-     * Configure les actions du panel (fermeture, drag).
+     * Configure les actions du panel (drag).
+     * Note: the close action is managed by the caller (e.g. MarkNote) so it is
+     * not overwritten here.
      */
     private void setupPanelActions(BasePanel panel, DockZone zone) {
-        // Fermeture = cacher le panel
-        panel.setOnClose(() -> hidePanel(panel));
-
-        // Activer le drag sur le header du panel
         enableDrag(panel);
     }
 
@@ -610,6 +608,34 @@ public class DockingManager {
     public void rememberPanelZone(BasePanel panel, DockZone zone) {
         if (panel != null && zone != null && zone != DockZone.CENTER) {
             lastPanelZone.put(panel, zone);
+        }
+    }
+
+    public double[] getHorizontalDividers() {
+        if (horizontalSplit != null && !horizontalSplit.getDividers().isEmpty()) {
+            return horizontalSplit.getDividers().stream()
+                    .mapToDouble(SplitPane.Divider::getPosition).toArray();
+        }
+        return new double[0];
+    }
+
+    public double[] getVerticalDividers() {
+        if (verticalSplit != null && !verticalSplit.getDividers().isEmpty()) {
+            return verticalSplit.getDividers().stream()
+                    .mapToDouble(SplitPane.Divider::getPosition).toArray();
+        }
+        return new double[0];
+    }
+
+    public void setHorizontalDividers(double[] positions) {
+        if (horizontalSplit != null && positions.length > 0) {
+            horizontalSplit.setDividerPositions(positions);
+        }
+    }
+
+    public void setVerticalDividers(double[] positions) {
+        if (verticalSplit != null && positions.length > 0) {
+            verticalSplit.setDividerPositions(positions);
         }
     }
 

--- a/src/main/java/ui/ProjectExplorerPanel.java
+++ b/src/main/java/ui/ProjectExplorerPanel.java
@@ -353,6 +353,11 @@ public class ProjectExplorerPanel extends BasePanel {
         return projectDir;
     }
 
+    @Override
+    public void afterReattach() {
+        refresh();
+    }
+
     /**
      * Définit le service git à utiliser pour les indicateurs visuels et les
      * opérations pull/push.

--- a/src/main/java/ui/PromptInputArea.java
+++ b/src/main/java/ui/PromptInputArea.java
@@ -9,8 +9,7 @@ import java.util.function.Consumer;
 
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.control.Button;
-import javafx.scene.control.Label;
+import javafx.scene.control.Button; 
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.Tooltip;

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -350,3 +350,7 @@ llm.config.refresh=Refresh Models
 
 # Menu LLM
 menu.view.llmPanel=LLM Chat
+
+# Mode lecture
+menu.view.readingMode=Mode lecture
+reading.mode.exit=Quitter le mode lecture

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -33,7 +33,7 @@ menu.help.about=À propos...
 about.title=À propos de MarkNote
 about.version=Version : {0}
 about.copyright=© SnapGames 2026
-about.author=Auteur : Frédéric Delorme
+about.author=Auteurs : Frédéric Delorme/JB Meyer
 app.version=0.1.4
 about.contact=Contact : contact.snapgames@gmail.com
 about.repository=Dépôt Git : https://github.com/mcgivrer/marknote
@@ -44,6 +44,8 @@ splash.close=Fermer
 
 # Actions panneaux génériques
 panel.detach.tooltip=Ouvrir dans un onglet
+panel.minimize.tooltip=Réduire le panneau
+panel.maximize.tooltip=Agrandir le panneau
 
 # Preview panel
 preview.title=Preview

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -354,3 +354,7 @@ llm.config.refresh=Modelle aktualisieren
 
 # Menü LLM
 menu.view.llmPanel=LLM Chat
+
+# Lesemodus
+menu.view.readingMode=Lesemodus
+reading.mode.exit=Lesemodus beenden

--- a/src/main/resources/i18n/messages_de.properties
+++ b/src/main/resources/i18n/messages_de.properties
@@ -33,7 +33,7 @@ menu.help.about=Über...
 about.title=Über MarkNote
 about.version=Version: {0}
 about.copyright=© SnapGames 2026
-about.author=Autor: Frédéric Delorme
+about.author=Autoren: Frédéric Delorme/JB Meyer
 app.version=0.1.4
 about.contact=Kontakt: contact.snapgames@gmail.com
 about.repository=Git-Repository: https://github.com/mcgivrer/marknote
@@ -44,6 +44,8 @@ splash.close=Schließen
 
 # Generische Panel-Aktionen
 panel.detach.tooltip=In einem Tab öffnen
+panel.minimize.tooltip=Panel minimieren
+panel.maximize.tooltip=Panel maximieren
 
 # Vorschau-Panel
 preview.title=Vorschau

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -357,3 +357,7 @@ llm.config.refresh=Refresh Models
 
 # Menu LLM
 menu.view.llmPanel=LLM Chat
+
+# Reading mode
+menu.view.readingMode=Enter Reading Mode
+reading.mode.exit=Exit Reading Mode

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -33,7 +33,7 @@ menu.help.about=About...
 about.title=About MarkNote
 about.version=Version: {0}
 about.copyright=© SnapGames 2026
-about.author=Author: Frédéric Delorme
+about.author=Authors: Frédéric Delorme/JB Meyer
 app.version=0.1.4
 about.contact=Contact: contact.snapgames@gmail.com
 about.repository=Git repository: https://github.com/mcgivrer/marknote
@@ -44,6 +44,8 @@ splash.close=Close
 
 # Generic panel actionsMot
 panel.detach.tooltip=Open in a tab
+panel.minimize.tooltip=Minimize panel
+panel.maximize.tooltip=Maximize panel
 
 # Preview panel
 preview.title=Preview

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -33,7 +33,7 @@ menu.help.about=Acerca de...
 about.title=Acerca de MarkNote
 about.version=Versión: {0}
 about.copyright=© SnapGames 2026
-about.author=Autor: Frédéric Delorme
+about.author=Autores: Frédéric Delorme/JB Meyer
 app.version=0.1.4
 about.contact=Contacto: contact.snapgames@gmail.com
 about.repository=Repositorio Git: https://github.com/mcgivrer/marknote
@@ -44,6 +44,8 @@ splash.close=Cerrar
 
 # Acciones de panel genéricas
 panel.detach.tooltip=Abrir en una pestaña
+panel.minimize.tooltip=Minimizar panel
+panel.maximize.tooltip=Maximizar panel
 
 # Panel de vista previa
 preview.title=Vista previa

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -355,3 +355,7 @@ llm.config.refresh=Actualizar modelos
 # Menú LLM
 menu.view.llmPanel=Chat LLM
 
+# Modo lectura
+menu.view.readingMode=Modo lectura
+reading.mode.exit=Salir del modo lectura
+

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -357,3 +357,7 @@ llm.config.refresh=Rafraîchir les modèles
 
 # Menu LLM
 menu.view.llmPanel=Chat LLM
+
+# Mode lecture
+menu.view.readingMode=Mode lecture
+reading.mode.exit=Quitter le mode lecture

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -33,7 +33,7 @@ menu.help.about=À propos...
 about.title=À propos de MarkNote
 about.version=Version : {0}
 about.copyright=© SnapGames 2026
-about.author=Auteur : Frédéric Delorme
+about.author=Auteurs : Frédéric Delorme/JB Meyer
 app.version=0.1.4
 about.contact=Contact : contact.snapgames@gmail.com
 about.repository=Dépôt Git : https://github.com/mcgivrer/marknote
@@ -44,6 +44,8 @@ splash.close=Fermer
 
 # Actions panneaux génériques
 panel.detach.tooltip=Ouvrir dans un onglet
+panel.minimize.tooltip=Réduire le panneau
+panel.maximize.tooltip=Agrandir le panneau
 
 # Preview panel
 preview.title=Preview

--- a/src/main/resources/i18n/messages_it.properties
+++ b/src/main/resources/i18n/messages_it.properties
@@ -33,7 +33,7 @@ menu.help.about=Informazioni...
 about.title=Informazioni su MarkNote
 about.version=Versione: {0}
 about.copyright=© SnapGames 2026
-about.author=Autore: Frédéric Delorme
+about.author=Autori: Frédéric Delorme/JB Meyer
 app.version=0.1.4
 about.contact=Contatto: contact.snapgames@gmail.com
 about.repository=Repository Git: https://github.com/mcgivrer/marknote
@@ -44,6 +44,8 @@ splash.close=Chiudi
 
 # Azioni pannello generiche
 panel.detach.tooltip=Apri in una scheda
+panel.minimize.tooltip=Minimizza pannello
+panel.maximize.tooltip=Massimizza pannello
 
 # Pannello anteprima
 preview.title=Anteprima

--- a/src/main/resources/i18n/messages_it.properties
+++ b/src/main/resources/i18n/messages_it.properties
@@ -354,3 +354,7 @@ llm.config.refresh=Aggiorna modelli
 # Menu LLM
 menu.view.llmPanel=Chat LLM
 
+# Modalità lettura
+menu.view.readingMode=Modalità lettura
+reading.mode.exit=Esci dalla modalità lettura
+


### PR DESCRIPTION
Entering reading mode goes full-screen, hides the menu bar and the editor pane, floats the project explorer in a small utility window above the preview, and hides the LLM chat and all other side panels. Exiting (via the top-right button or Escape) restores every panel and divider position to its previous state.

- MarkNote.java: promote root/topBar to fields; add enter/exit reading mode logic with floating Stage for the project explorer; add View menu item; suppress JavaFX full-screen exit hint
- pom.xml: fix exec plugin config (split JVM args, use ${java.home}, commandlineArgs + workingDirectory); add git.commit.id.abbrev fallback; enable native git for git-commit-id plugin
- i18n (6 files): add menu.view.readingMode and reading.mode.exit keys